### PR TITLE
chore: separate typecheck from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
     "dev": "astro dev",
     "dev:network": "astro dev --host",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "astro build",
     "preview": "astro preview",
     "preview:network": "astro dev --host",
     "astro": "astro",
     "lint": "eslint .",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "typecheck": "astro check"
   },
   "dependencies": {
     "@astrojs/check": "^0.5.6",


### PR DESCRIPTION
## Summary
- run astro build without typechecking
- add standalone `typecheck` script for `astro check`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896ad79c6408324ac5e828b98e27548