### PR TITLE
Limit header navigation to core sections

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -57,17 +57,13 @@ export const SEARCH: Page = {
 
 // Links
 export const LINKS: Links = [
-  { 
-    TEXT: "Home", 
-    HREF: "/", 
+  {
+    TEXT: "Home",
+    HREF: "/",
   },
   {
     TEXT: "Symptoms",
     HREF: "/symptoms",
-  },
-  {
-    TEXT: "Tree Shifts",
-    HREF: "/tree-shifts",
   },
   {
     TEXT: "Trees",
@@ -76,18 +72,6 @@ export const LINKS: Links = [
   {
     TEXT: "Foundations",
     HREF: "/foundations",
-  },
-  {
-    TEXT: "Canon Notes",
-    HREF: "/foundations/canon-notes",
-  },
-  {
-    TEXT: "Compass Points",
-    HREF: "/foundations/compass-points",
-  },
-  {
-    TEXT: "Pillars",
-    HREF: "/foundations/pillars",
   },
 ]
 


### PR DESCRIPTION
## Summary
- show only Home, Symptoms, Trees, Foundations in nav

## Testing
- `npm run build`
- `npm run typecheck`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_689ea1f9a4c48324bfa4c6864615d433