### PR TITLE
Use tree-shift front matter for symptoms

### DIFF
--- a/src/components/SymptomArrowCard.astro
+++ b/src/components/SymptomArrowCard.astro
@@ -36,7 +36,7 @@ const { fruit, blurb, tags = [], href, pillLabel = "system" } = Astro.props;
 
     {tags?.length > 0 && (
       <ul class="flex flex-wrap mt-2 gap-1">
-        {tags.map((tag: string) => (
+        {tags.slice(0, 3).map((tag: string) => (
           <li class="text-xs uppercase py-0.5 px-2 rounded bg-black/5 dark:bg-white/20 text-black/75 dark:text-white/75">
             {tag.length > 20 ? `${tag.slice(0, 20)}…` : tag}
           </li>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -77,22 +77,17 @@ const pillars = defineCollection({
   }),
 })
 
-const symptoms = defineCollection({
-  type: "data",
-  schema: z.object({
-    fruit: z.string(),
-    blurb: z.string(),
-    systemLabel: z.string(),
-    systemHref: z.string(),
-    tags: z.array(z.string()),
-  }),
-});
-
 const treeShifts = defineCollection({
   type: "content",
   schema: z.object({
     title: z.string(),
     description: z.string(),
+    fruit: z.string(),
+    blurb: z.string(),
+    systemLabel: z.string(),
+    tags: z.array(z.string()),
+    treeSlug: z.string().optional(),
+    pathwayId: z.string().optional(),
     date: z.coerce.date(),
     prevHref: z.string().optional(),
     prevLabel: z.string().optional(),
@@ -165,7 +160,6 @@ const pathways = defineCollection({
 });
 
 export const collections = {
-  symptoms,
   tree,
   canon_notes: canonNotes,
   compass_points: compassPoints,

--- a/src/content/symptoms/_cynicism.json
+++ b/src/content/symptoms/_cynicism.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Cynicism",
-  "blurb": "Sarcasm as armor; nothing surprises you except hope.",
-  "systemLabel": "Irony Armor",
-  "systemHref": "/system/irony-armor",
-  "tags": ["Shield", "Disappointment", "Trust"]
-}

--- a/src/content/symptoms/_despair.json
+++ b/src/content/symptoms/_despair.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Despair",
-  "blurb": "The story feels over; meaning evaporates.",
-  "systemLabel": "Nihilism",
-  "systemHref": "/system/nihilism",
-  "tags": ["Meaning", "Suffering", "End"]
-}

--- a/src/content/symptoms/_isolation.json
+++ b/src/content/symptoms/_isolation.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Isolation",
-  "blurb": "Withdrawing to avoid pain, then aching from the quiet.",
-  "systemLabel": "Self‑Protection",
-  "systemHref": "/system/self-protection",
-  "tags": ["Shame", "Walls", "Avoidance"]
-}

--- a/src/content/symptoms/_numbness.json
+++ b/src/content/symptoms/_numbness.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Numbness",
-  "blurb": "Scrolling, snacking, streaming—anything to not feel.",
-  "systemLabel": "Desensitization",
-  "systemHref": "/system/desensitization",
-  "tags": ["Avoidance", "Apathy", "Dopamine"]
-}

--- a/src/content/symptoms/_people-pleasing.json
+++ b/src/content/symptoms/_people-pleasing.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "People‑Pleasing",
-  "blurb": "Saying yes to avoid disapproval; resentment builds quietly.",
-  "systemLabel": "Approval Addiction",
-  "systemHref": "/system/approval-addiction",
-  "tags": ["Belonging", "Fear", "Masking"]
-}

--- a/src/content/symptoms/_restlessness.json
+++ b/src/content/symptoms/_restlessness.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Restlessness",
-  "blurb": "Can’t stop optimizing; still not arriving anywhere restful.",
-  "systemLabel": "Distraction Churn",
-  "systemHref": "/system/distraction-churn",
-  "tags": ["Hurry", "Novelty", "FOMO"]
-}

--- a/src/content/symptoms/anxiety.json
+++ b/src/content/symptoms/anxiety.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Anxiety",
-  "blurb": "Tight chest, racing thoughts, catastrophizing everyday choices.",
-  "systemLabel": "Performance Gospel",
-  "systemHref": "/tree-shifts/anxiety",
-  "tags": ["Fear", "Control", "Uncertainty"]
-}

--- a/src/content/symptoms/burnout.json
+++ b/src/content/symptoms/burnout.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Burnout",
-  "blurb": "Chronic exhaustion, cynicism, reduced capacity—even for what you love.",
-  "systemLabel": "Hustle/Burnout Loop",
-  "systemHref": "/tree-shifts/burnout",
-  "tags": ["Work", "Overdrive", "Worth"]
-}

--- a/src/content/symptoms/control.json
+++ b/src/content/symptoms/control.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Control",
-  "blurb": "If you’re not steering every wheel, you can’t breathe.",
-  "systemLabel": "Safety Idolatry",
-  "systemHref": "/tree-shifts/control",
-  "tags": ["Risk", "Safety", "Certainty"]
-}

--- a/src/content/symptoms/emotional-reactivity.json
+++ b/src/content/symptoms/emotional-reactivity.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Overrun by Emotion",
-  "blurb": "Outbursts, withdrawal, and spirals that leave you feeling ruled by your moods.",
-  "systemLabel": "Emotion-as-Identity",
-  "systemHref": "/tree-shifts/emotional-reactivity",
-  "tags": ["Emotions", "Reactivity", "Self-Control"]
-}

--- a/src/content/symptoms/envy-comparison.json
+++ b/src/content/symptoms/envy-comparison.json
@@ -1,7 +1,0 @@
-{
-  "fruit": "Envy / Comparison",
-  "blurb": "Other people’s wins feel like losses; your joy depends on their feed.",
-  "systemLabel": "Comparison Culture",
-  "systemHref": "/tree-shifts/envy",
-  "tags": ["Status", "Image", "Envy"]
-}

--- a/src/content/tree-shifts/anxiety.mdx
+++ b/src/content/tree-shifts/anxiety.mdx
@@ -3,7 +3,15 @@ title: "Anxiety"
 description: "Chronic worry, restlessness, and fear of the future."
 treeSlug: "trust-tree"
 date: 2025-08-31
-tags: [Anxiety, Worry, Fear]
+fruit: "Anxiety"
+blurb: "Tight chest, racing thoughts, catastrophizing everyday choices."
+systemLabel: "Performance Gospel"
+tags:
+  - Anxiety
+  - Worry
+  - Fear
+  - Control
+  - Uncertainty
 pathwayId: anxiety-trust
 ---
 

--- a/src/content/tree-shifts/burnout.mdx
+++ b/src/content/tree-shifts/burnout.mdx
@@ -3,6 +3,13 @@ title: "Symptom: Burnout"
 description: "Trace burnout from fruit to root, step out from Performance, and be grafted into Grace."
 date: "2025-08-22"
 treeSlug: "grace"
+fruit: "Burnout"
+blurb: "Chronic exhaustion, cynicism, reduced capacity—even for what you love."
+systemLabel: "Hustle/Burnout Loop"
+tags:
+  - Work
+  - Overdrive
+  - Worth
 ---
 
 import CTA from '../../components/CTA.astro'

--- a/src/content/tree-shifts/control.mdx
+++ b/src/content/tree-shifts/control.mdx
@@ -3,7 +3,15 @@ title: "Control"
 description: "Clinging to safety and certainty at the cost of peace."
 treeSlug: "surrender-tree"
 date: 2025-08-31
-tags: [Control, Fear, Safety]
+fruit: "Control"
+blurb: "If you’re not steering every wheel, you can’t breathe."
+systemLabel: "Safety Idolatry"
+tags:
+  - Control
+  - Fear
+  - Safety
+  - Risk
+  - Certainty
 pathwayId: control-surrender
 ---
 

--- a/src/content/tree-shifts/emotional-reactivity.mdx
+++ b/src/content/tree-shifts/emotional-reactivity.mdx
@@ -3,10 +3,13 @@ title: "Overrun by Emotion"
 description: "When feelings take the driver’s seat of your life."
 treeSlug: "spirit-led-identity"
 date: "2025-08-28"
-tags: 
-    - Emotions
-    - Self-Control
-    - Reactivity
+fruit: "Overrun by Emotion"
+blurb: "Outbursts, withdrawal, and spirals that leave you feeling ruled by your moods."
+systemLabel: "Emotion-as-Identity"
+tags:
+  - Emotions
+  - Self-Control
+  - Reactivity
 ---
 
 import CTA from '../../components/CTA.astro'

--- a/src/content/tree-shifts/envy.mdx
+++ b/src/content/tree-shifts/envy.mdx
@@ -3,6 +3,13 @@ title: "Envy"
 description: "Resentment when others flourish while you feel empty."
 treeSlug: "gratitude"
 date: 2025-08-25
+fruit: "Envy / Comparison"
+blurb: "Other people’s wins feel like losses; your joy depends on their feed."
+systemLabel: "Comparison Culture"
+tags:
+  - Status
+  - Image
+  - Envy
 ---
 
 import CTA from '../../components/CTA.astro'

--- a/src/pages/symptoms/index.astro
+++ b/src/pages/symptoms/index.astro
@@ -6,10 +6,10 @@ import BottomLayout from "@layouts/BottomLayout.astro";
 import { SYMPTOMS } from "@consts";
 import SymptomArrowCard from "@components/SymptomArrowCard.astro";
 
-// Pull symptoms from the content collection
-const entries = await getCollection("symptoms");
+// Pull tree shifts and treat them as symptoms
+const entries = await getCollection("tree-shifts");
 const symptoms = entries
-  .map((e) => ({ id: e.id, ...e.data }))
+  .map((e) => ({ slug: e.slug, ...e.data }))
   .sort((a, b) => a.fruit.localeCompare(b.fruit));
 ---
 
@@ -50,7 +50,7 @@ const symptoms = entries
             fruit={it.fruit}
             blurb={it.blurb}
             tags={it.tags}
-            href={it.systemHref}
+            href={`/tree-shifts/${it.slug}`}
             pillLabel={it.systemLabel}
           />
         </li>


### PR DESCRIPTION
## Summary
- Move symptom metadata into each tree-shift MDX file
- Drop separate symptoms content collection and schema
- Generate symptoms page from tree-shifts instead of standalone JSON files
- Merge existing tree-shift tags with symptom tags when both are present
- Limit symptom cards to displaying three tags to reduce visual overload

## Testing
- `npm run lint` *(fails: ESLint couldn't find config file)*
- `npm run typecheck` *(fails: Property 'draft' does not exist on type; 18 errors)*
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b855b306bc8324bf4997b88997bb3f