### PR TITLE
Remove Vercel analytics import to fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@astrojs/solid-js": "^4.0.1",
     "@astrojs/tailwind": "^5.1.0",
     "@tailwindcss/typography": "^0.5.10",
-    "@vercel/analytics": "^1.6.1",
     "astro": "^4.4.13",
     "clsx": "^2.1.0",
     "fuse.js": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.10
         version: 0.5.19(tailwindcss@3.4.19(yaml@2.8.2))
-      '@vercel/analytics':
-        specifier: ^1.6.1
-        version: 1.6.1
       astro:
         specifier: ^4.4.13
         version: 4.16.19(rollup@4.57.0)(typescript@5.9.3)
@@ -745,29 +742,6 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  '@vercel/analytics@1.6.1':
-    resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
       vue-router:
         optional: true
 
@@ -3182,8 +3156,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
-
-  '@vercel/analytics@1.6.1': {}
 
   '@volar/kit@2.4.27(typescript@5.9.3)':
     dependencies:

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -4,7 +4,6 @@ import BaseHead from "@components/BaseHead.astro"
 import Header from "@components/Header.astro"
 import Footer from "@components/Footer.astro"
 import Drawer from "@components/Drawer.astro"
-import Analytics from "@vercel/analytics/astro"
 const { title, description } = Astro.props
 import { SITE } from "@consts"
 ---
@@ -13,7 +12,6 @@ import { SITE } from "@consts"
 <html lang="en">
   <head>
     <BaseHead title={`${title} | ${SITE.TITLE}`} description={description} />
-    <Analytics />
   </head>
   <body>
     <Header />


### PR DESCRIPTION
### Motivation
- The Vercel analytics integration caused the Vercel build to fail because the package could not be resolved/installed from the environment (registry `403`) and produced an unresolved import during bundling. 

### Description
- Remove the `@vercel/analytics/astro` import and the `<Analytics />` component from `src/layouts/PageLayout.astro`. 
- Drop `@vercel/analytics` from `package.json` dependencies. 
- Clean up corresponding entries for `@vercel/analytics` in `pnpm-lock.yaml` so the lockfile no longer references the package.

### Testing
- Running `npm install` previously failed with a `403 Forbidden` fetching `@vercel/analytics`. 
- `npm run build` before the change failed with a Rollup/Vite error about unresolved import `@vercel/analytics/astro`. 
- `npm run build` after removing the analytics import progressed much further but ultimately failed with the sitemap plugin error `Cannot read properties of undefined (reading 'reduce')`, so the repo still has a failing automated build step due to the sitemap plugin.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cb324ebc88324a4d15c0e29581c1c)